### PR TITLE
Added Antivirus System (Automatic operation）

### DIFF
--- a/2024ACCDGameJam/Assets/Scenes/Yixin_TestScene.unity
+++ b/2024ACCDGameJam/Assets/Scenes/Yixin_TestScene.unity
@@ -1019,6 +1019,51 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!1 &1735462963
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1735462965}
+  - component: {fileID: 1735462964}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1735462964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735462963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7e296295f04af4683e27d78c462768, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  antivirusSpeed: 5
+--- !u!4 &1735462965
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1735462963}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.5092365, y: 0.25088483, z: -0.004500015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1852457083
 GameObject:
   m_ObjectHideFlags: 0
@@ -1229,3 +1274,4 @@ SceneRoots:
   - {fileID: 751307728}
   - {fileID: 1852457086}
   - {fileID: 140129807}
+  - {fileID: 1735462965}

--- a/2024ACCDGameJam/Assets/Script/AntivirusSystem.cs
+++ b/2024ACCDGameJam/Assets/Script/AntivirusSystem.cs
@@ -1,0 +1,83 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AntivirusSystem : MonoBehaviour
+{
+    public float antivirusSpeed = 5f; // Antivirus software reduces the speed at which infections progress. !!!!!! Modify it!!!!!!!
+    private bool isAntivirusRunning = false;
+    private GameObject currentTarget = null; // The target file currently being processed
+
+    public void StartAntivirus(bool isOwnerWatching, Dictionary<string, GameObject> computerFileDictionary)
+    {
+        if (isOwnerWatching && !isAntivirusRunning)
+        {
+            StartCoroutine(RunAntivirusAfterDelay(3f, computerFileDictionary));
+        }
+        else if (!isOwnerWatching && isAntivirusRunning)
+        {
+            StopAntivirus(); // Stop antivirus software
+        }
+    }
+
+    private IEnumerator RunAntivirusAfterDelay(float delay, Dictionary<string, GameObject> computerFileDictionary)
+    {
+        yield return new WaitForSeconds(delay);
+
+        isAntivirusRunning = true;
+        StartCoroutine(CheckAndReduceInfection(computerFileDictionary));
+    }
+
+    private IEnumerator CheckAndReduceInfection(Dictionary<string, GameObject> computerFileDictionary)
+    {
+        while (isAntivirusRunning)
+        {
+            // Checks all files for files that are being infected
+            currentTarget = FindInfectedFile(computerFileDictionary);
+
+            if (currentTarget != null)
+            {
+                // Get the IsFile component of a file and reduce the infection progress
+                var fileComponent = currentTarget.GetComponent<IsFile>();
+                fileComponent.currentProcess -= antivirusSpeed * Time.deltaTime;
+
+                // Make sure progress doesn't drop to negative values
+                if (fileComponent.currentProcess < 0)
+                    fileComponent.currentProcess = 0;
+
+                // If the infection is completely cleared, reset the current target
+                if (fileComponent.currentProcess == 0)
+                {
+                    fileComponent.hasVirus = false; // clear virus status
+                    currentTarget = null;
+                    // UI changes
+                }
+            }
+
+            yield return null; // Update once per frame
+        }
+    }
+
+    private GameObject FindInfectedFile(Dictionary<string, GameObject> computerFileDictionary)
+    {
+        // Iterate over all files and return the first file with an infection progress between 0-100%
+        foreach (var fileEntry in computerFileDictionary)
+        {
+            var fileObject = fileEntry.Value;
+            var fileComponent = fileObject.GetComponent<IsFile>();
+
+            if (fileComponent != null && fileComponent.hasVirus && fileComponent.currentProcess > 0 && fileComponent.currentProcess < 100)
+            {
+                return fileObject;
+            }
+        }
+        return null; // If no file being infected is found, null is returned.
+    }
+
+    private void StopAntivirus()
+    {
+        isAntivirusRunning = false;
+        currentTarget = null; // Reset current target
+        StopCoroutine(CheckAndReduceInfection(null));
+    }
+}

--- a/2024ACCDGameJam/Assets/Script/AntivirusSystem.cs.meta
+++ b/2024ACCDGameJam/Assets/Script/AntivirusSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f7e296295f04af4683e27d78c462768
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I added the script named AntivirusSystem. 
Add this script to the game manager object of the Yixin Test Scene. 


**Functions:** 
StartAntivirus: 
Controlled by the state of owner, when isOwnerWatching is true, starts the antivirus software and passes in the dictionary of all files, computerFileDictionary.

RunAntivirusAfterDelay: 
Starts the CheckAndReduceInfection coroutine after a 3 second delay, periodically checking and reducing the infection progress of files.

CheckAndReduceInfection:
Call FindInfectedFile to check all files and find a target file with an infection progress between 0-100%.
If a qualifying file is found, reduce its infectionProgress value until the infection progress drops to 0 and reset hasVirus to false.

FindInfectedFile:
Traverse the computerFileDictionary dictionary and return the first file with an infection progress between 0-100%.
Only qualifying files will be returned, ensuring that only one file is processed at a time.

StopAntivirus: 
Call this method to stop the antivirus software's cleaning process when the owner state changes and is no longer looking at the screen.